### PR TITLE
fix: typo + missing var for cni_helper + Affinity issue with cni_helper

### DIFF
--- a/terraform/live/sample/eks/terraform.tfvars
+++ b/terraform/live/sample/eks/terraform.tfvars
@@ -189,9 +189,10 @@ virtual_kubelet = {
   cloudwatch_log_group = "eks-virtual-kubelet"
 }
 
-cni_metrics_helper {
+cni_metrics_helper = {
   create_iam_resources = true
   create_iam_resources_kiam = false
+  attach_to_pool = 0
   use_kiam = false
   iam_policy = <<POLICY
 {

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -726,6 +726,7 @@ spec:
         iam.amazonaws.com/role: "${join(",", aws_iam_role.eks-cni-metrics-helper-kiam.*.arn)}"
     spec:
       serviceAccountName: cni-metrics-helper
+      ${var.cni_metrics_helper["use_kiam"] ? indent(6, var.cni_metrics_helper["deployment_scheduling_kiam"]) : indent(6, var.cni_metrics_helper["deployment_scheduling"] ) }
       containers:
       - image: 694065802095.dkr.ecr.us-west-2.amazonaws.com/cni-metrics-helper:0.1.1
         imagePullPolicy: Always
@@ -733,7 +734,6 @@ spec:
         env:
           - name: USE_CLOUDWATCH
             value: "yes"
-            ${var.cni_metrics_helper["use_kiam"] ? indent(6, var.cni_metrics_helper["deployment_scheduling_kiam"]) : indent(6, var.cni_metrics_helper["deployment_scheduling"] ) }
 CNI_METRICS_HELPER
 }
 


### PR DESCRIPTION
I had an issue with some things (missing var and missing "=" because I hate typos.
Also had a weird issue with the node affinity var not working, as is I had the following error: 
```
clusterrolebinding.rbac.authorization.k8s.io/cni-metrics-helper created
error: error validating "STDIN": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]): unknown field "nodeAffinity" in io.k8s.api.core.v1.Container; if you choose to ignore these errors, turn validation off with --validate=false
[terragrunt] 2019/02/22 16:23:07 Error running hook cni_metrics_helper with message: exit status 1
[terragrunt] 2019/02/22 16:23:07 Hit multiple errors:
Hit multiple errors:
exit status 1
```

Moving the `${var.cni_metrics_helper["use_kiam"] ? indent(6, var.cni_metrics_helper["deployment_scheduling_kiam"]) : indent(6, var.cni_metrics_helper["deployment_scheduling"] ) }` line before container spec seems to resolve the issue.