### PR TITLE
fix: update Flux Helm repository Git URL (1.x release branch)

### DIFF
--- a/terraform/modules/eks-addons/helm_repositories.tf
+++ b/terraform/modules/eks-addons/helm_repositories.tf
@@ -1,6 +1,6 @@
 data "helm_repository" "flux" {
   name = "flux"
-  url  = "https://weaveworks.github.io/flux"
+  url  = "https://fluxcd.github.io/flux/"
 }
 
 data "helm_repository" "stable" {


### PR DESCRIPTION
This was fixed on master, but not on the 1.x release branch I'm currently using.