### PR TITLE
fix: update Flux Helm repository Git URL to official URL.

### DIFF
--- a/terraform/modules/eks-addons/helm_repositories.tf
+++ b/terraform/modules/eks-addons/helm_repositories.tf
@@ -1,6 +1,6 @@
 data "helm_repository" "flux" {
   name = "flux"
-  url  = "https://raw.githubusercontent.com/fluxcd/flux/gh-pages/"
+  url  = "https://fluxcd.github.io/flux/"
 }
 
 data "helm_repository" "stable" {
@@ -12,4 +12,3 @@ data "helm_repository" "incubator" {
   name = "incubator"
   url  = "https://kubernetes-charts-incubator.storage.googleapis.com/"
 }
-


### PR DESCRIPTION
See https://github.com/fluxcd/flux/wiki/MoveToFluxCD for details.

Signed-off-by: Benoît Faucon <benoit.faucon@mindsay.com>