### PR TITLE
Allow Flux to create PodMonitors.

### DIFF
--- a/terraform/modules/eks-namespaces/namespaces.tf
+++ b/terraform/modules/eks-namespaces/namespaces.tf
@@ -86,6 +86,7 @@ resource "kubernetes_role" "flux" {
     resources = [
       "prometheusrules",
       "servicemonitors",
+      "podmonitors",
     ]
 
     verbs = ["*"]


### PR DESCRIPTION
Since we allow Flux to create ServiceMonitors, there is no reason not to allow PodMonitors as well.

On my local module (created before you added the `eks-namespaces` module here), I also allow AlertManagers and Prometheuses, but I don't know whether you want to do that here.